### PR TITLE
Corrections to Unicode To HTML Converter

### DIFF
--- a/Ruby/Braking/brake.rb
+++ b/Ruby/Braking/brake.rb
@@ -26,7 +26,7 @@ class Brake
     @strategy.power_dissipation(velocity, self)
   end
 
-  def force_at_break_level percentage_of_peak_force
+  def force_at_brake_level percentage_of_peak_force
     PEAK_FORCE * percentage_of_peak_force
   end
 

--- a/Ruby/Braking/brake.rb
+++ b/Ruby/Braking/brake.rb
@@ -1,0 +1,35 @@
+class Brake
+  
+  def initialize(strategy)
+    @strategy = strategy
+  end
+  
+  def set_peak_force new_value
+    PEAK_FORCE = new_value
+  end
+
+  def peak_force
+    PEAK_FORCE
+  end
+
+  def power_dissipation velocity
+    if @strategy.nil?
+      if velocity < 60
+        @strategy = SteadyBrakingStrategy.new
+      elsif velocity < 120
+        @strategy = IntervalBrakingStrategy.new
+      else
+        @strategy = FailingBrakingStrategy.new
+      end
+    end
+ 
+    @strategy.power_dissipation(velocity, self)
+  end
+
+  def force_at_break_level percentage_of_peak_force
+    PEAK_FORCE * percentage_of_peak_force
+  end
+
+  private
+  PEAK_FORCE = 30
+end

--- a/Ruby/Braking/failing_braking_strategy.rb
+++ b/Ruby/Braking/failing_braking_strategy.rb
@@ -1,0 +1,9 @@
+class FailingBrakingStrategy
+  def power_dissipation(velocity, brake)
+    percent = (50 + Random.new(1234).rand(50))
+    force = brake.force_at_brake_level(percent)*velocity
+    brake.set_peak_force(brake.peak_force()*0.99) 
+    
+    force
+  end
+end

--- a/Ruby/Braking/interval_braking_strategy.rb
+++ b/Ruby/Braking/interval_braking_strategy.rb
@@ -1,0 +1,5 @@
+class IntervalBrakingStrategy
+  def power_dissipation(velocity, brake)
+    brake.force_at_brake_level(100.0)*velocity/1.5;
+  end
+end

--- a/Ruby/Braking/steady_braking_strategy.rb
+++ b/Ruby/Braking/steady_braking_strategy.rb
@@ -1,0 +1,5 @@
+class SteadyBrakingStrategy
+  def power_dissipation(velocity, brake)
+    brake.force_at_brake_level(100.0) * velocity
+  end
+end

--- a/Ruby/TextConverter/unicode_to_html_converter.rb
+++ b/Ruby/TextConverter/unicode_to_html_converter.rb
@@ -1,19 +1,21 @@
 require 'cgi'
 
 class UnicodeFileToHtmlTextConverter
-
-  def initialize(full_filename_with_path):
+  attr_accessor :full_filename_with_path
+  def initialize(full_filename_with_path)
     @full_filename_with_path = full_filename_with_path
   end
 
   def convert_to_html
+    html = ""
     File.open(self.full_filename_with_path, "r") do |f|
-      html = ""
       while (line = f.gets)
           line = line.chomp()
-          html += CGI.escapeHTML(line, quote=True)
+          html += CGI.escapeHTML(line)
           html += "<br />"
       end
-      html
+    end
+
+    return html
   end
 end

--- a/Ruby/TirePressure/tire_pressure.rb
+++ b/Ruby/TirePressure/tire_pressure.rb
@@ -7,8 +7,7 @@ class Sensor
     Sensor.OFFSET + self.sample_pressure()
   end
 
-  @staticmethod
-  def sample_pressure
+  def self.sample_pressure
     # placeholder implementation that simulate a real sensor in a real tire
     6 * rand * rand
   end


### PR DESCRIPTION
Syntax error corrected - removed colon; 
missing accessor method for the path to the file;
'escapeHTML' method takes 1 arg rather than 2;
initialise html string outside of File open code block and constructed HTML.