### PR TITLE
Update .net framework version to v3.5

### DIFF
--- a/CSharp/TDDMicroExercises.csproj
+++ b/CSharp/TDDMicroExercises.csproj
@@ -10,11 +10,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TDDMicroExercises</RootNamespace>
     <AssemblyName>TDDMicroExercises</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <OldToolsVersion>2.0</OldToolsVersion>
     <UpgradeBackupLocation />
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
to at least be able to install a mock library through nuget.
With .net 2.0, problem is that....
* If you try to add a package through the nuget manager,
 you have no error but no packages are found and you don't know why :(
* If you do it within the Package Manager Console, the error is not very straight forward.

I think we should update the targeted version.
That should not be a big deal now that there is a free community version
 of Visual Studio....