### PR TITLE
Add java version in pom.xml files for compat with java 11

### DIFF
--- a/Java/Leaderboard/pom.xml
+++ b/Java/Leaderboard/pom.xml
@@ -4,6 +4,10 @@
     <groupId>Leaderboard</groupId>
     <artifactId>Leaderboard</artifactId>
     <version>0.0.1-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/Java/TelemetrySystem/pom.xml
+++ b/Java/TelemetrySystem/pom.xml
@@ -4,6 +4,10 @@
     <groupId>TelemetrySystem</groupId>
     <artifactId>TelemetrySystem</artifactId>
     <version>0.0.1-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/Java/TextConverter/pom.xml
+++ b/Java/TextConverter/pom.xml
@@ -4,6 +4,10 @@
     <groupId>TextConverter</groupId>
     <artifactId>TextConverter</artifactId>
     <version>0.0.1-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -25,5 +29,5 @@
 		    <scope>test</scope>
 		</dependency>
     </dependencies>
-    
+
 </project>

--- a/Java/TirePressureMonitoringSystem/pom.xml
+++ b/Java/TirePressureMonitoringSystem/pom.xml
@@ -4,6 +4,10 @@
     <groupId>TirePressureMonitoringSystem</groupId>
     <artifactId>TirePressureMonitoringSystem</artifactId>
     <version>0.0.1-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/Java/TurnTicketDispenser/pom.xml
+++ b/Java/TurnTicketDispenser/pom.xml
@@ -4,6 +4,10 @@
     <groupId>TurnTicketDispenser</groupId>
     <artifactId>TurnTicketDispenser</artifactId>
     <version>0.0.1-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
When using this repo with Java 11 and maven 3.6, the Java katas fail to run because maven assumes that the code uses Java 1.5 by default.

This MR adds an explicit java version to the `pom.xml` files.

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.
```