### PR TITLE
Update C# example to use .Net Core 3.1 with xUnit test project template

### DIFF
--- a/CSharp/Leaderboard.Tests/LeaderboardTest.cs
+++ b/CSharp/Leaderboard.Tests/LeaderboardTest.cs
@@ -1,25 +1,25 @@
 using System.Collections.Generic;
-using NUnit.Framework;
+using Xunit;
 
 namespace TDDMicroExercises.LeaderBoard.Tests
 {
     public class LeaderboardTest
     {
-        [Test]
+        [Fact]
         public void ShouldSumThePoints()
         {
             var results = TestData.SampleLeaderboard1.DriverResults();
-            Assert.IsTrue(results.ContainsKey("Lewis Hamilton"));
-            Assert.AreEqual(18 + 18 + 25, results["Lewis Hamilton"]);
+            Assert.True(results.ContainsKey("Lewis Hamilton"));
+            Assert.Equal(18 + 18 + 25, results["Lewis Hamilton"]);
         }
 
-        [Test]
+        [Fact]
         public void ShouldFindTheWinner()
         {
-            Assert.AreEqual("Lewis Hamilton", TestData.SampleLeaderboard1.DriverRankings()[0]);
+            Assert.Equal("Lewis Hamilton", TestData.SampleLeaderboard1.DriverRankings()[0]);
         }
 
-        [Test]
+        [Fact]
         public void ShouldKeepAllDriversWhenSamePoints()
         {
             var winDriver1 = new Race("Australian Grand Prix", TestData.Driver1, TestData.Driver2, TestData.Driver3);
@@ -28,8 +28,8 @@ namespace TDDMicroExercises.LeaderBoard.Tests
 
             var rankings = exEquoLeaderBoard.DriverRankings();
 
-            CollectionAssert.AreEqual(
-                new List<string> {TestData.Driver2.Name, TestData.Driver1.Name, TestData.Driver3.Name},
+            Assert.Equal(
+                new List<string> { TestData.Driver2.Name, TestData.Driver1.Name, TestData.Driver3.Name },
                 rankings);
         }
     }

--- a/CSharp/Leaderboard.Tests/RaceTest.cs
+++ b/CSharp/Leaderboard.Tests/RaceTest.cs
@@ -1,15 +1,15 @@
-using NUnit.Framework;
+using Xunit;
 
 namespace TDDMicroExercises.LeaderBoard.Tests
 {
     public class RaceTest
     {
-        [Test]
+        [Fact]
         public void ShouldCalculateDriverPoints()
         {
-            Assert.AreEqual(25, TestData.Race1.GetPoints(TestData.Driver1));
-            Assert.AreEqual(18, TestData.Race1.GetPoints(TestData.Driver2));
-            Assert.AreEqual(15, TestData.Race1.GetPoints(TestData.Driver3));
+            Assert.Equal(25, TestData.Race1.GetPoints(TestData.Driver1));
+            Assert.Equal(18, TestData.Race1.GetPoints(TestData.Driver2));
+            Assert.Equal(15, TestData.Race1.GetPoints(TestData.Driver3));
         }
     }
 }

--- a/CSharp/TDDMicroExercises.csproj
+++ b/CSharp/TDDMicroExercises.csproj
@@ -1,86 +1,22 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.50727</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{BBCF3C67-8E31-48E3-AD2E-8C605E2E07BE}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>TDDMicroExercises</RootNamespace>
-    <AssemblyName>TDDMicroExercises</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <OldToolsVersion>2.0</OldToolsVersion>
-    <UpgradeBackupLocation />
-    <TargetFrameworkProfile />
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>packages\NUnit.3.6.0\lib\net35\nunit.framework.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="LeaderBoard\Driver.cs" />
-    <Compile Include="LeaderBoard\Leaderboard.cs" />
-    <Compile Include="LeaderBoard.Tests\LeaderboardTest.cs" />
-    <Compile Include="LeaderBoard\Race.cs" />
-    <Compile Include="LeaderBoard.Tests\RaceTest.cs" />
-    <Compile Include="LeaderBoard\SelfDrivingCar.cs" />
-    <Compile Include="TelemetrySystem\TelemetryClient.cs" />
-    <Compile Include="TelemetrySystem.Tests\TelemetryDiagnosticControlsTest.cs" />
-    <Compile Include="TelemetrySystem\TelemetryDiagnosticControls.cs" />
-    <Compile Include="LeaderBoard.Tests\TestData.cs" />
-    <Compile Include="TirePressureMonitoringSystem.Tests\AlarmTest.cs" />
-    <Compile Include="TirePressureMonitoringSystem\Alarm.cs" />
-    <Compile Include="TirePressureMonitoringSystem\Sensor.cs" />
-    <Compile Include="TurnTicketDispenser\TicketDispenser.cs" />
-    <Compile Include="TurnTicketDispenser\TurnNumberSequence.cs" />
-    <Compile Include="TurnTicketDispenser\TurnTicket.cs" />
-    <Compile Include="UnicodeFileToHtmlTextConverter.Tests\UnicodeFileToHtmlTextConverterTest.cs" />
-    <Compile Include="UnicodeFileToHtmlTextConverter\UnicodeFileToHtmlTextConverter.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/CSharp/TDDMicroExercises.sln
+++ b/CSharp/TDDMicroExercises.sln
@@ -1,7 +1,9 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TDDMicroExercises", "TDDMicroExercises.csproj", "{BBCF3C67-8E31-48E3-AD2E-8C605E2E07BE}"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30330.147
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TDDMicroExercises", "TDDMicroExercises.csproj", "{99C7E4FB-3830-4B16-B622-B185E1D0E42E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -9,12 +11,15 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{BBCF3C67-8E31-48E3-AD2E-8C605E2E07BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BBCF3C67-8E31-48E3-AD2E-8C605E2E07BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BBCF3C67-8E31-48E3-AD2E-8C605E2E07BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BBCF3C67-8E31-48E3-AD2E-8C605E2E07BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99C7E4FB-3830-4B16-B622-B185E1D0E42E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99C7E4FB-3830-4B16-B622-B185E1D0E42E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99C7E4FB-3830-4B16-B622-B185E1D0E42E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99C7E4FB-3830-4B16-B622-B185E1D0E42E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EC43307C-DED1-4ED6-9A2E-1A9CEAC15C52}
 	EndGlobalSection
 EndGlobal

--- a/CSharp/TelemetrySystem.Tests/TelemetryDiagnosticControlsTest.cs
+++ b/CSharp/TelemetrySystem.Tests/TelemetryDiagnosticControlsTest.cs
@@ -1,14 +1,12 @@
-using NUnit.Framework;
+using Xunit;
 
 namespace TDDMicroExercises.TelemetrySystem.Tests
 {
-    [TestFixture]
     public class TelemetryDiagnosticControlsTest
     {
-        [Test]
+        [Fact]
         public void CheckTransmission_should_send_a_diagnostic_message_and_receive_a_status_message_response()
         {
         }
-
     }
 }

--- a/CSharp/TelemetrySystem/TelemetryClient.cs
+++ b/CSharp/TelemetrySystem/TelemetryClient.cs
@@ -2,92 +2,91 @@ using System;
 
 namespace TDDMicroExercises.TelemetrySystem
 {
-  public class TelemetryClient
-  {
-    public const string DiagnosticMessage = "AT#UD";
-
-    private bool _onlineStatus;
-    private string _diagnosticMessageResult = string.Empty;
-
-    private readonly Random _connectionEventsSimulator = new Random(42);
-
-    public bool OnlineStatus
+    public class TelemetryClient
     {
-      get { return _onlineStatus; }
-    }
+        public const string DiagnosticMessage = "AT#UD";
 
-    public void Connect(string telemetryServerConnectionString)
-    {
-      if (string.IsNullOrEmpty(telemetryServerConnectionString))
-      {
-        throw new ArgumentNullException();
-      }
+        private bool _onlineStatus;
+        private string _diagnosticMessageResult = string.Empty;
 
-      // simulate the operation on a real modem
-      bool success = _connectionEventsSimulator.Next(1, 10) <= 8;
+        private readonly Random _connectionEventsSimulator = new Random(42);
 
-      _onlineStatus = success;
-
-    }
-
-    public void Disconnect()
-    {
-      _onlineStatus = false;
-    }
-
-    public void Send(string message)
-    {
-      if (string.IsNullOrEmpty(message))
-      {
-        throw new ArgumentNullException();
-      }
-
-      if (message == DiagnosticMessage)
-      {
-        // simulate a status report
-        _diagnosticMessageResult =
-            "LAST TX rate................ 100 MBPS\r\n"
-          + "HIGHEST TX rate............. 100 MBPS\r\n"
-          + "LAST RX rate................ 100 MBPS\r\n"
-          + "HIGHEST RX rate............. 100 MBPS\r\n"
-          + "BIT RATE.................... 100000000\r\n"
-          + "WORD LEN.................... 16\r\n"
-          + "WORD/FRAME.................. 511\r\n"
-          + "BITS/FRAME.................. 8192\r\n"
-          + "MODULATION TYPE............. PCM/FM\r\n"
-          + "TX Digital Los.............. 0.75\r\n"
-          + "RX Digital Los.............. 0.10\r\n"
-          + "BEP Test.................... -5\r\n"
-          + "Local Rtrn Count............ 00\r\n"
-          + "Remote Rtrn Count........... 00";
-
-        return;
-      }
-  
-      // here should go the real Send operation
-    }
-
-    public string Receive()
-    {
-      string message;
-
-      if (string.IsNullOrEmpty(_diagnosticMessageResult) == false)
-      {
-        message = _diagnosticMessageResult;
-        _diagnosticMessageResult = string.Empty;
-      } 
-      else
-      {                
-        // simulate a received message
-        message = string.Empty;
-        int messageLenght = _connectionEventsSimulator.Next(50, 110);
-        for(int i = messageLenght; i >=0; --i)
+        public bool OnlineStatus
         {
-          message += (char)_connectionEventsSimulator.Next(40, 126);
+            get { return _onlineStatus; }
         }
-      }
 
-      return message;
+        public void Connect(string telemetryServerConnectionString)
+        {
+            if (string.IsNullOrEmpty(telemetryServerConnectionString))
+            {
+                throw new ArgumentNullException();
+            }
+
+            // simulate the operation on a real modem
+            bool success = _connectionEventsSimulator.Next(1, 10) <= 8;
+
+            _onlineStatus = success;
+        }
+
+        public void Disconnect()
+        {
+            _onlineStatus = false;
+        }
+
+        public void Send(string message)
+        {
+            if (string.IsNullOrEmpty(message))
+            {
+                throw new ArgumentNullException();
+            }
+
+            if (message == DiagnosticMessage)
+            {
+                // simulate a status report
+                _diagnosticMessageResult =
+                    "LAST TX rate................ 100 MBPS\r\n"
+                  + "HIGHEST TX rate............. 100 MBPS\r\n"
+                  + "LAST RX rate................ 100 MBPS\r\n"
+                  + "HIGHEST RX rate............. 100 MBPS\r\n"
+                  + "BIT RATE.................... 100000000\r\n"
+                  + "WORD LEN.................... 16\r\n"
+                  + "WORD/FRAME.................. 511\r\n"
+                  + "BITS/FRAME.................. 8192\r\n"
+                  + "MODULATION TYPE............. PCM/FM\r\n"
+                  + "TX Digital Los.............. 0.75\r\n"
+                  + "RX Digital Los.............. 0.10\r\n"
+                  + "BEP Test.................... -5\r\n"
+                  + "Local Rtrn Count............ 00\r\n"
+                  + "Remote Rtrn Count........... 00";
+
+                return;
+            }
+
+            // here should go the real Send operation
+        }
+
+        public string Receive()
+        {
+            string message;
+
+            if (string.IsNullOrEmpty(_diagnosticMessageResult) == false)
+            {
+                message = _diagnosticMessageResult;
+                _diagnosticMessageResult = string.Empty;
+            }
+            else
+            {
+                // simulate a received message
+                message = string.Empty;
+                int messageLenght = _connectionEventsSimulator.Next(50, 110);
+                for (int i = messageLenght; i >= 0; --i)
+                {
+                    message += (char)_connectionEventsSimulator.Next(40, 126);
+                }
+            }
+
+            return message;
+        }
     }
-  }
 }

--- a/CSharp/TirePressureMonitoringSystem.Tests/AlarmTest.cs
+++ b/CSharp/TirePressureMonitoringSystem.Tests/AlarmTest.cs
@@ -1,16 +1,14 @@
-
-using NUnit.Framework;
+using Xunit;
 
 namespace TDDMicroExercises.TirePressureMonitoringSystem
 {
-    [TestFixture]
     public class AlarmTest
     {
-        [Test]
+        [Fact]
         public void Foo()
         {
             Alarm alarm = new Alarm();
-            Assert.AreEqual(false, alarm.AlarmOn);
+            Assert.False(alarm.AlarmOn);
         }
     }
 }

--- a/CSharp/TirePressureMonitoringSystem/Alarm.cs
+++ b/CSharp/TirePressureMonitoringSystem/Alarm.cs
@@ -26,6 +26,5 @@ namespace TDDMicroExercises.TirePressureMonitoringSystem
         {
             get { return _alarmOn; }
         }
-
     }
 }

--- a/CSharp/TurnTicketDispenser/TurnTicket.cs
+++ b/CSharp/TurnTicketDispenser/TurnTicket.cs
@@ -13,6 +13,5 @@ namespace TDDMicroExercises.TurnTicketDispenser
         {
             get { return _turnNumber; }
         }
-
     }
 }

--- a/CSharp/UnicodeFileToHtmlTextConverter.Tests/UnicodeFileToHtmlTextConverterTest.cs
+++ b/CSharp/UnicodeFileToHtmlTextConverter.Tests/UnicodeFileToHtmlTextConverterTest.cs
@@ -1,15 +1,14 @@
 
-using NUnit.Framework;
+using Xunit;
 namespace TDDMicroExercises.UnicodeFileToHtmlTextConverter
 {
-    [TestFixture]
     public class HikerTest
     {
-        [Test]
-        public void foobar()
+        [Fact]
+        public void Foobar()
         {
             UnicodeFileToHtmlTextConverter converter = new UnicodeFileToHtmlTextConverter("foobar.txt");
-            Assert.AreEqual("fixme", converter.GetFilename());
+            Assert.Equal("fixme", converter.GetFilename());
         }
     }
 }

--- a/CSharp/UnicodeFileToHtmlTextConverter/UnicodeFileToHtmlTextConverter.cs
+++ b/CSharp/UnicodeFileToHtmlTextConverter/UnicodeFileToHtmlTextConverter.cs
@@ -1,12 +1,10 @@
 using System.IO;
-using System.Web;
 
 namespace TDDMicroExercises.UnicodeFileToHtmlTextConverter
 {
     public class UnicodeFileToHtmlTextConverter
     {
         private string _fullFilenameWithPath;
-
 
         public UnicodeFileToHtmlTextConverter(string fullFilenameWithPath)
         {

--- a/CSharp/packages.config
+++ b/CSharp/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="3.6.0" targetFramework="net35" />
-</packages>


### PR DESCRIPTION
As I plan to attempt this kata series with my team, I needed to make some changes to the C# example to utilize the current version of .Net Core 3.1 as well as the xUnit project template available inside Visual Studio. I thought this might be a useful update to your repository so I am opening a PR with the changes. I hope this helps keep these examples up to date! 😄 