### PR TITLE
Reduced fields' visibilities

### DIFF
--- a/Java/TirePressureMonitoringSystem/src/main/java/tddmicroexercises/tirepressuremonitoringsystem/Alarm.java
+++ b/Java/TirePressureMonitoringSystem/src/main/java/tddmicroexercises/tirepressuremonitoringsystem/Alarm.java
@@ -5,9 +5,9 @@ public class Alarm
     private final double LowPressureThreshold = 17;
     private final double HighPressureThreshold = 21;
 
-    private Sensor sensor = new Sensor();
+    protected Sensor sensor = new Sensor();
 
-    private boolean alarmOn = false;
+    protected boolean alarmOn = false;
 
     public void check()
     {

--- a/Java/TirePressureMonitoringSystem/src/main/java/tddmicroexercises/tirepressuremonitoringsystem/Alarm.java
+++ b/Java/TirePressureMonitoringSystem/src/main/java/tddmicroexercises/tirepressuremonitoringsystem/Alarm.java
@@ -5,9 +5,9 @@ public class Alarm
     private final double LowPressureThreshold = 17;
     private final double HighPressureThreshold = 21;
 
-    Sensor sensor = new Sensor();
+    private Sensor sensor = new Sensor();
 
-    boolean alarmOn = false;
+    private boolean alarmOn = false;
 
     public void check()
     {


### PR DESCRIPTION
Fix for Issue #47, reduced field visibility of `alarmOn` and `sensor` to `private` which makes it impossible (or at least harder/awkward) to get the sensor under test without changing the production code. 

`sensor` could be `final` (which would envolve to _blank final_ when having a constructor taking a `sensor`) but I think a `private final` `sensor` would be more confusing than helpful.  