### PR TITLE
Having constants that follows the java naming conventions

### DIFF
--- a/Java/TirePressureMonitoringSystem/src/main/java/tddmicroexercises/tirepressuremonitoringsystem/Alarm.java
+++ b/Java/TirePressureMonitoringSystem/src/main/java/tddmicroexercises/tirepressuremonitoringsystem/Alarm.java
@@ -2,8 +2,8 @@ package tddmicroexercises.tirepressuremonitoringsystem;
 
 public class Alarm
 {
-    private final double LowPressureThreshold = 17;
-    private final double HighPressureThreshold = 21;
+    private static final double LOW_PRESSURE_THRESHOLD = 17;
+    private static final double HIGH_PRESSURE_THRESHOLD = 21;
 
     protected Sensor sensor = new Sensor();
 
@@ -13,7 +13,7 @@ public class Alarm
     {
         double psiPressureValue = sensor.popNextPressurePsiValue();
 
-        if (psiPressureValue < LowPressureThreshold || HighPressureThreshold < psiPressureValue)
+        if (psiPressureValue < LOW_PRESSURE_THRESHOLD || HIGH_PRESSURE_THRESHOLD < psiPressureValue)
         {
             alarmOn = true;
         }


### PR DESCRIPTION
@EsterDanielYtterbrink pointed out today that we did show code in our learning hour that had warnings from SonarQube noted in our IDE. 
This is because we were using the code unchanged and the two variables could be constants and also the existing variable name does not match the java naming conventions. 

Just copied the code as it already was done at https://github.com/emilybache/TirePressure-Kata/blob/88f76769ff9f42282154f20c8395a13d70404a23/java/src/main/java/org/example/Alarm.java#L5C1-L6C62